### PR TITLE
[1.1.1] - Hotkeys fixes

### DIFF
--- a/src/components/AddNewTodoForm.tsx
+++ b/src/components/AddNewTodoForm.tsx
@@ -53,6 +53,7 @@ export default function AddNewTodoForm({
     setLocalStorageValue("todoList", updatedTodoList);
 
     form.reset();
+    inputRef.current.blur();
     setSelectedItem(updatedTodoList[0]);
   };
 

--- a/src/components/AddNewTodoForm.tsx
+++ b/src/components/AddNewTodoForm.tsx
@@ -16,6 +16,7 @@ import { getTodoList, setLocalStorageValue } from "@/lib/utils";
 import { useGlobalContext } from "@/contexts";
 import { v4 as uuid } from "uuid";
 import { useEffect, useRef } from "react";
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 
 const formSchema = z.object({
   taskName: z.string(),
@@ -55,30 +56,29 @@ export default function AddNewTodoForm({
     setSelectedItem(updatedTodoList[0]);
   };
 
+  const handleKeyUp = (e: ReactKeyboardEvent<HTMLFormElement>) => {
+    e.stopPropagation();
+    if (e.code === "Escape") {
+      inputRef.current.blur();
+      setSelectedItem(context.todoList[0]);
+    }
+
+    if (e.code === "ArrowUp" || e.code === "ArrowDown") {
+      inputRef.current.blur();
+    }
+  };
+
   const handleInputFocus = (e: KeyboardEvent) => {
     if (e.ctrlKey && e.code === "KeyN") {
       form.setFocus("taskName");
     }
   };
 
-  const handleInputBlur = (e: KeyboardEvent) => {
-    if (e.code === "Escape") {
-      inputRef.current.blur();
-      setSelectedItem(context.todoList[0]);
-    }
-
-    if (e.key === "ArrowUp" || e.key === "ArrowDown") {
-      inputRef.current.blur();
-    }
-  };
-
   useEffect(() => {
     document.addEventListener("keyup", handleInputFocus);
-    inputRef.current?.addEventListener("keyup", handleInputBlur);
 
     return () => {
       document.removeEventListener("keyup", handleInputFocus);
-      inputRef.current?.removeEventListener("keyup", handleInputBlur);
     };
   }, []);
 
@@ -88,6 +88,7 @@ export default function AddNewTodoForm({
         onSubmit={form.handleSubmit(onSubmit)}
         className="flex"
         onChange={() => setSelectedItem(null)}
+        onKeyUp={(e) => handleKeyUp(e)}
       >
         <FormField
           control={form.control}

--- a/src/components/AddNewTodoForm.tsx
+++ b/src/components/AddNewTodoForm.tsx
@@ -52,35 +52,50 @@ export default function AddNewTodoForm({
     setLocalStorageValue("todoList", updatedTodoList);
 
     form.reset();
-    inputRef.current.blur();
     setSelectedItem(updatedTodoList[0]);
   };
 
-  const handleKeyUp = (e: KeyboardEvent) => {
-    if (!e.ctrlKey || e.code !== "KeyN") return;
+  const handleInputFocus = (e: KeyboardEvent) => {
+    if (e.ctrlKey && e.code === "KeyN") {
+      form.setFocus("taskName");
+    }
+  };
 
-    setSelectedItem(null);
-    form.setFocus("taskName");
+  const handleInputBlur = (e: KeyboardEvent) => {
+    if (e.code === "Escape") {
+      inputRef.current.blur();
+      setSelectedItem(context.todoList[0]);
+    }
   };
 
   useEffect(() => {
-    document.addEventListener("keyup", handleKeyUp);
+    document.addEventListener("keyup", handleInputFocus);
+    inputRef.current?.addEventListener("keyup", handleInputBlur);
 
     return () => {
-      document.removeEventListener("keyup", handleKeyUp);
+      document.removeEventListener("keyup", handleInputFocus);
+      inputRef.current?.removeEventListener("keyup", handleInputBlur);
     };
   }, []);
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="flex">
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="flex"
+        onChange={() => setSelectedItem(null)}
+      >
         <FormField
           control={form.control}
           name="taskName"
           render={({ field }) => (
             <FormItem className="flex-grow mr-4">
               <FormControl ref={inputRef}>
-                <Input placeholder="Write a new task..." {...field} />
+                <Input
+                  placeholder="Write a new task..."
+                  onFocus={() => setSelectedItem(null)}
+                  {...field}
+                />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/src/components/AddNewTodoForm.tsx
+++ b/src/components/AddNewTodoForm.tsx
@@ -66,6 +66,10 @@ export default function AddNewTodoForm({
       inputRef.current.blur();
       setSelectedItem(context.todoList[0]);
     }
+
+    if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+      inputRef.current.blur();
+    }
   };
 
   useEffect(() => {

--- a/src/components/EditTime.tsx
+++ b/src/components/EditTime.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import type { KeyboardEvent } from "react";
 import { Input } from "./ui/input";
 import {
   createDynamicMask,
@@ -35,28 +36,23 @@ export default function EditTime({
     setChangeTime(updatedTime);
   };
 
-  useEffect(() => {
-    const handleKeyUp = (e: KeyboardEvent) => {
-      if (!isActiveItem) return;
+  const handleKeyUp = (e: KeyboardEvent<HTMLInputElement>) => {
+    e.stopPropagation();
+    if (!isActiveItem) return;
 
-      switch (e.key) {
-        case "Enter": {
-          handleTimeChange(changeTime);
-          break;
-        }
-        case "Escape": {
-          setIsEditing(false);
-          break;
-        }
-        default:
-        //no-op
+    switch (e.key) {
+      case "Enter": {
+        handleTimeChange(changeTime);
+        break;
       }
-    };
-
-    document.addEventListener("keyup", handleKeyUp);
-
-    return () => document.removeEventListener("keyup", handleKeyUp);
-  }, [handleTimeChange]);
+      case "Escape": {
+        setIsEditing(false);
+        break;
+      }
+      default:
+      //no-op
+    }
+  };
 
   return (
     <MaskedInput
@@ -64,6 +60,7 @@ export default function EditTime({
       value={changeTime}
       onClick={() => setActiveItem()}
       onChange={(e) => handleInputChange(e.target.value)}
+      onKeyUp={(e) => handleKeyUp(e)}
       placeholder="00:00:00"
       render={(ref, props) => (
         <Input

--- a/src/components/EditTime.tsx
+++ b/src/components/EditTime.tsx
@@ -40,7 +40,7 @@ export default function EditTime({
     e.stopPropagation();
     if (!isActiveItem) return;
 
-    switch (e.key) {
+    switch (e.code) {
       case "Enter": {
         handleTimeChange(changeTime);
         break;

--- a/src/hooks/useArrowNavigation.ts
+++ b/src/hooks/useArrowNavigation.ts
@@ -16,15 +16,16 @@ export default function useArrowNavigation({
     (e: KeyboardEvent) => {
       if (todoList.length === 0) return;
 
-      const currentSelectedItemId = selectedItemId.current;
-
-      if (!currentSelectedItemId) {
-        setSelectedItem(todoList[0]);
-        return;
-      }
-
       if (e.key === "ArrowUp" || e.key === "ArrowDown") {
         e.preventDefault();
+
+        const currentSelectedItemId = selectedItemId.current;
+
+        if (!currentSelectedItemId) {
+          setSelectedItem(todoList[0]);
+          return;
+        }
+
         const currentIndex = todoList.findIndex(
           (todoItem) => todoItem.id === currentSelectedItemId
         );

--- a/src/hooks/useArrowNavigation.ts
+++ b/src/hooks/useArrowNavigation.ts
@@ -50,9 +50,7 @@ export default function useArrowNavigation({
   );
 
   useEffect(() => {
-    if (!selectedItem) return;
-
-    selectedItemId.current = selectedItem.id;
+    selectedItemId.current = selectedItem?.id || null;
   }, [selectedItem]);
 
   useEffect(() => {


### PR DESCRIPTION
- Isolate input keyup events to prevent them from triggering global document events of app.
- Extend selection reset logic when operating with "add new" input (submit or escape call)
- Refactor and unify all event key references to `e.code`
- Fix stale data of `selectedItemId` ref when invoking `setSelectedItem`
- Fix unexpected `setSelectedItem` call when `ArrowUp` / `ArrowDown` keys are pressed